### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/AllenDang/findfont-rs/compare/v0.1.0...v0.1.1) - 2025-02-24
+
+### Other
+
+- Update demo code in README
+- Update crates.io and docs.rs links
+- release v0.1.0
+
 ## [0.1.0](https://github.com/AllenDang/findfont-rs/releases/tag/v0.1.0) - 2025-02-24
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "findfont"
-version = "0.1.0"
+version = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "findfont"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "find font by file name"
 categories = ["filesystem"]


### PR DESCRIPTION



## 🤖 New release

* `findfont`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/AllenDang/findfont-rs/compare/v0.1.0...v0.1.1) - 2025-02-24

### Other

- Update demo code in README
- Update crates.io and docs.rs links
- release v0.1.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).