### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/AllenDang/findfont-rs/compare/v0.1.1...v0.1.2) - 2025-05-06
+
+### Other
+
+- ...
+- exposing more of the API and adding brief comments with examples
+- Update lib.rs
+- Update lib.rs
+- Update findfont.rs
+
 ## [0.1.1](https://github.com/AllenDang/findfont-rs/compare/v0.1.0...v0.1.1) - 2025-02-24
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "findfont"
-version = "0.1.1"
+version = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "findfont"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "find font by file name"
 categories = ["filesystem"]


### PR DESCRIPTION



## 🤖 New release

* `findfont`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/AllenDang/findfont-rs/compare/v0.1.1...v0.1.2) - 2025-05-06

### Other

- ...
- exposing more of the API and adding brief comments with examples
- Update lib.rs
- Update lib.rs
- Update findfont.rs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).