### PR TITLE
fix: Implement home directory expansion

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,0 +1,29 @@
+name: Rust build and test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install DejaVu Fonts (Ubuntu only)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y fonts-dejavu
+
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose
+      - name: Run clippy (lint)
+        run: cargo clippy -- -D clippy:all
+      - name: Check formatting
+        run: cargo fmt --all -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,219 @@
 version = 4
 
 [[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "findfont"
 version = "0.1.1"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.172"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ exclude = ["/.github", ".gitignore"]
 rust-version = "1.85.0"
 
 [dependencies]
+dirs = "6.0"

--- a/src/findfont.rs
+++ b/src/findfont.rs
@@ -1,5 +1,6 @@
 #[cfg(not(target_os = "macos"))]
 use std::env;
+use std::fs;
 use std::path::PathBuf;
 
 #[cfg(target_os = "linux")]
@@ -15,14 +16,37 @@ fn split_path_list(path_list: &str) -> Vec<String> {
     }
 }
 
+#[cfg(target_os = "macos")]
+fn get_macos_sys_font_dirs() -> Vec<PathBuf> {
+    const SYS_FONT_PATHS: &[&str] = &[
+        "/Library/Fonts/",
+        "/System/Library/Fonts/",
+        "/System/Library/Fonts/Supplemental",
+        "/System/Library/AssetsV2/com_apple_MobileAsset_Font7/3419f2a427639ad8c8e139149a287865a90fa17e.asset/AssetData",
+    ];
+
+    let mut font_dirs = Vec::with_capacity(5);
+
+    if let Some(home_dir) = dirs::home_dir() {
+        font_dirs.push(home_dir.join("Library/Fonts/"));
+    }
+    font_dirs.extend(SYS_FONT_PATHS.iter().map(|p| PathBuf::from(*p)));
+
+    font_dirs
+}
+
 #[cfg(target_os = "linux")]
 fn get_linux_sys_font_dirs() -> Vec<PathBuf> {
-    let mut font_dirs: Vec<PathBuf> = vec![
-        PathBuf::from("~/.fonts/"),
-        PathBuf::from("~/.local/share/fonts/"),
-        PathBuf::from("/usr/local/share/fonts/"),
-        PathBuf::from("/usr/share/fonts/"),
-    ];
+    const SYS_FONT_PATHS: &[&str] = &["/usr/share/fonts/", "/usr/local/share/fonts/"];
+
+    let mut font_dirs = Vec::with_capacity(6);
+
+    if let Some(home) = dirs::home_dir() {
+        font_dirs.push(home.join(".fonts/"));
+        font_dirs.push(home.join(".local/share/fonts/"));
+    }
+
+    font_dirs.extend(SYS_FONT_PATHS.iter().map(|p| PathBuf::from(*p)));
 
     if let Ok(data_path) = env::var("XDG_DATA_HOME") {
         if !data_path.is_empty() {
@@ -44,22 +68,16 @@ fn get_linux_sys_font_dirs() -> Vec<PathBuf> {
 
 ///
 /// Will return all font sys directories that are known for the current platform
-/// 
+///
 /// # Examples
 /// ```
 /// let dirs = findfont::get_sys_font_dirs();
-/// 
+///
 /// assert!(dirs.len() > 0, "Seems like your system is not supported or it does not have known font directories :(");
 /// ```
 pub fn get_sys_font_dirs() -> Vec<PathBuf> {
     #[cfg(target_os = "macos")]
-    let dirs = vec![
-        PathBuf::from("~/Library/Fonts/"),
-        PathBuf::from("/Library/Fonts/"),
-        PathBuf::from("/System/Library/Fonts/"),
-        PathBuf::from("/System/Library/Fonts/Supplemental"),
-        PathBuf::from("/System/Library/AssetsV2/com_apple_MobileAsset_Font7/3419f2a427639ad8c8e139149a287865a90fa17e.asset/AssetData")
-    ];
+    let dirs = get_macos_sys_font_dirs();
 
     #[cfg(target_os = "windows")]
     let dirs = vec![
@@ -78,52 +96,87 @@ pub fn get_sys_font_dirs() -> Vec<PathBuf> {
 
 ///
 /// Will return the first font sys directory that exists
-/// 
+///
 /// # Examples
 /// ```
 /// let dir = findfont::get_sys_font_dir();
-/// 
+///
 /// assert!(dir.is_some(), "Seems like your system is not supported or it does not have known font directory :(");
 /// ```
-/// 
 pub fn get_sys_font_dir() -> Option<PathBuf> {
-    get_sys_font_dirs().iter()
-    .filter(|path| std::path::Path::new(path).exists())
-    .map(|path| -> PathBuf { path.clone() })
-    .next()
+    get_sys_font_dirs()
+        .into_iter()
+        .find(|path| std::path::Path::new(path).exists())
 }
 
-///
 /// Will return the path to the requested font in system font directories (font file included).
-/// None will be returned in case the font is not found
-/// 
+/// [`None`] will be returned in case the font is not found.
+///
+/// **Note:** `font_name` should only have the font name without file extensions or spaces.
+///
 /// # Examples
+///
 /// ```
 /// let font_name = "Arial";
 /// let font = findfont::find(font_name);
-/// 
-/// assert!(font.is_some());
 /// ```
-/// 
+///
 pub fn find(font_name: &str) -> Option<PathBuf> {
     let exts = ["ttf", "ttc", "otf"];
-    let variant = ["Light", "Medium"];
+    let variants = ["Light", "Medium"];
 
     for dir in get_sys_font_dirs().iter() {
-        for ext in exts.iter() {
-            let font_path = dir.join(format!("{}.{}", font_name, ext));
-            if font_path.exists() {
-                return Some(font_path);
-            }
+        if let Some(found_path) = find_font_in_dir_recursive(dir, font_name, &exts, &variants) {
+            return Some(found_path);
+        }
+    }
 
-            for var in variant.iter() {
-                let font_path = dir.join(format!("{} {}.{}", font_name, var, ext));
-                if font_path.exists() {
-                    return Some(font_path);
+    None
+}
+
+/// Recursively searches for a font file in the given directory and its subdirectories.
+///
+/// Note: This will not follow symlinks to avoid potential infinite loops.
+fn find_font_in_dir_recursive(
+    dir_path: &PathBuf,
+    font_name: &str,
+    exts: &[&str],
+    variants: &[&str],
+) -> Option<PathBuf> {
+    let Ok(entries) = fs::read_dir(dir_path) else {
+        return None;
+    };
+
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+
+        if path.is_dir() && !path.is_symlink() {
+            if let Some(found_path) = find_font_in_dir_recursive(&path, font_name, exts, variants) {
+                return Some(found_path);
+            }
+        } else if path.is_file() {
+            let file_stem = path.file_stem().and_then(|s| s.to_str());
+            let file_ext = path.extension().and_then(|s| s.to_str());
+
+            if let Some((file_stem, file_ext)) = file_stem.zip(file_ext) {
+                for ext in exts {
+                    if !file_ext.eq_ignore_ascii_case(ext) {
+                        continue;
+                    }
+
+                    if file_stem.eq_ignore_ascii_case(font_name) {
+                        return Some(path);
+                    }
+
+                    for var in variants {
+                        let variant_font_name = format!("{}-{}", font_name, var);
+                        if file_stem.eq_ignore_ascii_case(&variant_font_name) {
+                            return Some(path);
+                        }
+                    }
                 }
             }
         }
     }
-
     None
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,18 +10,24 @@ mod tests {
 
     #[test]
     fn find_works() {
+        #[cfg(any(target_os = "macos", target_os = "windows"))]
         let font_name = "Arial";
+
+        // Due to licensing, Arial (and other Microsoft fonts) may not be available on Linux.
+        #[cfg(target_os = "linux")]
+        let font_name = "DejaVuSans";
+
         let font = findfont::find(font_name);
 
         println!("Font path: {}", font.clone().unwrap().display());
         assert!(font.is_some());
     }
 
-	#[test]
-	fn get_sys_font_dir_works() {
-		let dir = findfont::get_sys_font_dir();
+    #[test]
+    fn get_sys_font_dir_works() {
+        let dir = findfont::get_sys_font_dir();
 
-		println!("Font path: {}", dir.clone().unwrap().display());
-		assert!(dir.is_some());
-	}
+        println!("Font path: {}", dir.clone().unwrap().display());
+        assert!(dir.is_some());
+    }
 }


### PR DESCRIPTION
Previously, the home folders were not being searched because Rust's standard library does not automatically expand `~` to the user's home directory. This has been fixed by explicitly expanding the home directory in the code.

This also adds a GitHub Actions workflow to run tests on pull requests.